### PR TITLE
feat: Build and publish wheels via Cloud Build

### DIFF
--- a/python/cloudbuild-master.yaml
+++ b/python/cloudbuild-master.yaml
@@ -14,9 +14,10 @@ steps:
     id: "test"
 
   - name: 'python:3.9.4'
-    dir: /workspace/python/src
+    dir: /workspace/python
     script: |
       #!/usr/bin/env bash
-      python3 setup.py sdist
+      # Build sdist and wheel from src/
+      python3 -m build src --sdist --wheel --outdir dist/
       python3 -m twine upload --repository-url https://us-central1-python.pkg.dev/repcore-prod/python/ dist/*
     id: "publish"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,6 +2,7 @@ appengine-python-standard==1.1.5
 attrs==24.2.0
 backports.tarfile==1.2.0
 blinker==1.9.0
+build==1.2.2.post1
 cachetools==5.5.0
 certifi==2024.8.30
 charset-normalizer==3.4.0
@@ -59,4 +60,5 @@ twine==6.0.1
 typing-extensions==4.12.2
 urllib3==1.26.20
 werkzeug==3.1.3
+wheel==0.45.1
 zipp==3.21.0

--- a/python/src/setup.py
+++ b/python/src/setup.py
@@ -6,7 +6,7 @@ import setuptools
 # To debug, set DISTUTILS_DEBUG env var to anything.
 setuptools.setup(
     name="GoogleAppEnginePipeline",
-    version="2.0.0a13",
+    version="2.0.0",
     packages=setuptools.find_packages(),
     author="Google App Engine",
     author_email="app-engine-pipeline-api@googlegroups.com",


### PR DESCRIPTION
Updates Cloud Build to generate and publish wheel artifacts alongside sdist for GoogleAppEnginePipeline.